### PR TITLE
Fix stderr_print which seems like an outdated reference to the method…

### DIFF
--- a/lib/libfs.bash
+++ b/lib/libfs.bash
@@ -124,7 +124,7 @@ configure_permissions_ownership() {
                 chgrp -LR "$group" "$p"
             fi
         else
-            stderr_print "$p does not exist"
+            error "$p does not exist"
         fi
     done
 }


### PR DESCRIPTION
After trying to use it, I found that "stderr_print" is not defined.

It might have been an old reference to the error function.

I renamed it to use error, which seems like the correct function.